### PR TITLE
feat: adding dynamic translation to SqlAlchemy models

### DIFF
--- a/src/app/api_services/api_services_view.py
+++ b/src/app/api_services/api_services_view.py
@@ -3,7 +3,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 
 from app import appbuilder
 from app.api_services.api_services import ExtendedService
-
+from config import DB_LANGUAGES
 
 class ExtendedServiceView(ModelView):
     datamodel = SQLAInterface(ExtendedService)
@@ -11,8 +11,11 @@ class ExtendedServiceView(ModelView):
     list_columns = [
         "name",
         "description",
+         *[f"description_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "short_description",
+         *[f"short_description_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "specifications",
+         *[f"specifications_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "documentation_url",
         "unit_price",
         "service_url",
@@ -23,8 +26,11 @@ class ExtendedServiceView(ModelView):
     add_columns = [
         "name",
         "description",
+        *[f"description_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "short_description",
+        *[f"short_description_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "specifications",
+        *[f"specifications_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "documentation_url",
         "unit_price",
         "service_url",
@@ -35,8 +41,11 @@ class ExtendedServiceView(ModelView):
     edit_columns = [
         "name",
         "description",
+        *[f"description_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "short_description",
+        *[f"short_description_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "specifications",
+        *[f"specifications_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "documentation_url",
         "unit_price",
         "service_url",
@@ -47,8 +56,11 @@ class ExtendedServiceView(ModelView):
     show_columns = [
         "name",
         "description",
+        *[f"description_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "short_description",
+        *[f"short_description_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "specifications",
+        *[f"specifications_{lang}" for lang in DB_LANGUAGES if lang != 'en'], 
         "documentation_url",
         "unit_price",
         "service_url",

--- a/src/app/controllers/service_controllers.py
+++ b/src/app/controllers/service_controllers.py
@@ -7,6 +7,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 
 from app import appbuilder
 from app.models.service_models import Service
+from config import DB_LANGUAGES
 
 _logger = logging.getLogger(__name__)
 
@@ -14,12 +15,15 @@ _service_value_display_columns = [
     "id",
     "name",
     "description",
+    *[f"description_{lang}" for lang in DB_LANGUAGES if lang != 'en'],
     "documentation_url",
     "unit_price",
     "service_url",
     "image_service",
     "short_description",
+    *[f"short_description_{lang}" for lang in DB_LANGUAGES if lang != 'en'],
     "specifications",
+    *[f"specifications_{lang}" for lang in DB_LANGUAGES if lang != 'en'],
     "is_in_favorite",
     "api_playground_url",
 ]

--- a/src/app/models/plan_models.py
+++ b/src/app/models/plan_models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from flask_appbuilder import Model
+from config import DB_LANGUAGES
 from flask_appbuilder.models.mixins import AuditMixin
 from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
@@ -9,6 +9,9 @@ class Plan(Model):
     id = Column(Integer, primary_key=True)
     name = Column(String(255), nullable=False)
     description = Column(String(255), nullable=False)
+    for lang in DB_LANGUAGES:
+        if lang!= 'en':
+            locals()[f'description_{lang}'] = Column(String(255), nullable=True)
     service_plans = relationship("ServicePlan")
 
 

--- a/src/app/models/service_models.py
+++ b/src/app/models/service_models.py
@@ -8,6 +8,7 @@ from app import db
 from app.models.my_favorites_models import MyFavorites
 from app.utils.utils import get_user
 
+from config import DB_LANGUAGES
 
 class Service(Model):
     id = Column(Integer, primary_key=True)
@@ -28,6 +29,12 @@ class Service(Model):
     myfavorites = relationship("MyFavorites", back_populates="service", overlaps="service")
     type = Column(String(50), default="service", nullable=False)
     service_slug = Column(String(255), unique=True, default="temp-slug")
+
+    for lang in DB_LANGUAGES:
+        if lang != 'en':
+            locals()[f'description_{lang}'] = Column(Text, nullable=True)
+            locals()[f'short_description_{lang}'] = Column(String(255), nullable=True)
+            locals()[f'specifications_{lang}'] = Column(Text, nullable=True)
 
     __mapper_args__ = {"polymorphic_identity": "service", "polymorphic_on": type}
 

--- a/src/app/models/service_plan_option_models.py
+++ b/src/app/models/service_plan_option_models.py
@@ -8,6 +8,7 @@ from app import appbuilder, db
 from datetime import datetime
 from flask import jsonify
 import logging
+from config import DB_LANGUAGES
 
 _logger = logging.getLogger(__name__)
 
@@ -18,7 +19,10 @@ class ServicePlanOption(Model):
         "service_plan.id"), nullable=False)
     service_plan = relationship("ServicePlan")
     icon = Column(String)
-    html_content = Column(Text)
-
+    html_content = Column(Text) 
+    
+    for lang in DB_LANGUAGES:
+        if lang != 'en':
+            locals()[f'html_content_{lang}'] = Column(Text, nullable=True)
     def __repr__(self):
         return f"{self.icon} {self.html_content}"

--- a/src/config.py
+++ b/src/config.py
@@ -3,9 +3,15 @@ import os
 import urllib.request
 from datetime import timedelta
 
-from flask_appbuilder.security.manager import AUTH_OAUTH
+from flask_appbuilder.security.manager import AUTH_OAUTH, AUTH_DB
 
 basedir = os.path.abspath(os.path.dirname(__file__))
+
+# Here we define the supported langages in the database
+
+# Whenever you add a new language, you need to add it here and update 
+# the database so the fields are created and can be edited
+DB_LANGUAGES = ["en","fr", "ar"]
 
 KEYKCLOAK_URL = os.getenv("KEYKCLOAK_URL", " https://auth.dev.deploily.cloud")
 


### PR DESCRIPTION
**I have addd the translation to the SqlAlchemy models**

there are no changes in the api responds that could break the app, only added the translation fields along side the original once, e.g:
```
{
      "api_playground_url": "utl",
      "description": "description EN",
      "description_ar": null,
      "description_fr": "description FR",
      "documentation_url": "url",
      "id": 1,
      "image_service": null,
      "is_in_favorite": false,
      "name": "name",
      "service_url": "url",
      "short_description": "short description en",
      "short_description_ar": null,
      "short_description_fr": "short description fr",
      "specifications": "",
      "specifications_ar": null,
      "specifications_fr": null,
      "unit_price": null
    },
```

To add / remove a laguage you only edit the variable in config.py :
```
DB_LANGUAGES = ["en","fr", "ar"]
```

these fields are managed by the admin in the FAB console